### PR TITLE
Rewrite libcap_psx_test to verify thread synchronization behavior

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -54,7 +54,7 @@ endif
 
 test:
 ifeq ($(PTHREADS),yes)
-	$(MAKE) run_psx_test run_libcap_psx_test
+	$(MAKE) run_psx_test run_libcap_test run_libcap_psx_test
 ifeq ($(SHARED),yes)
 	$(MAKE) run_b219174
 endif
@@ -74,11 +74,17 @@ run_psx_test: psx_test
 psx_test: psx_test.c $(DEPS)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $< -o $@ $(LINKEXTRA) $(LIBPSXLIB)
 
+run_libcap_test: libcap_test
+	./libcap_test
+
+libcap_test: libcap_psx_test.c $(DEPS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $< -o $@ $(LINKEXTRA) $(LIBCAPLIB) -lpthread
+
 run_libcap_psx_test: libcap_psx_test
 	./libcap_psx_test
 
 libcap_psx_test: libcap_psx_test.c $(DEPS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $< -o $@ $(LINKEXTRA) $(LIBCAPLIB) $(LIBPSXLIB)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -DEXPECT_PSX_SYNC $(LDFLAGS) $< -o $@ $(LINKEXTRA) $(LIBCAPLIB) $(LIBPSXLIB)
 
 # privileged
 uns_test: uns_test.c $(DEPS)
@@ -144,6 +150,6 @@ endif
 endif
 
 clean:
-	rm -f psx_test libcap_psx_test libcap_launch_test uns_test *~
+	rm -f psx_test libcap_test libcap_psx_test libcap_launch_test uns_test *~
 	rm -f libcap_launch_test libcap_psx_launch_test core noop
 	rm -f exploit noexploit exploit.o weaver.so b219174

--- a/tests/libcap_psx_test.c
+++ b/tests/libcap_psx_test.c
@@ -10,65 +10,167 @@
 #include <sys/psx_syscall.h>
 #include <sys/prctl.h>
 #include <sys/types.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
-static void *thread_fork_exit(void *data) {
-    usleep(1234);
-    pid_t pid = fork();
-    long int start = cap_prctl(PR_GET_KEEPCAPS, 0, 0, 0, 0, 0);
-    if (start == -1) {
-	perror("FAILED: unable to start");
-	exit(1);
+#define NUM_THREADS 5
+
+/*
+ * Shared state to coordinate threads and track results
+ */
+static pthread_barrier_t barrier;
+static volatile int keepcaps_values[NUM_THREADS];
+static volatile int thread_ready = 0;
+
+/*
+ * Worker thread that reads its own KEEPCAPS state after the main thread
+ * modifies it using cap_prctlw().
+ *
+ * With libpsx: thread should see the synchronized value
+ * Without libpsx: thread keeps its original value
+ */
+static void *worker_thread(void *arg) {
+    int thread_id = *(int *)arg;
+    long int value;
+
+    /* Wait for all threads to be created */
+    pthread_barrier_wait(&barrier);
+
+    /* Signal ready and wait for main thread to modify KEEPCAPS */
+    __sync_fetch_and_add(&thread_ready, 1);
+    pthread_barrier_wait(&barrier);
+
+    /* Small delay to ensure main thread's cap_prctlw() has completed */
+    usleep(10000);
+
+    /* Read this thread's KEEPCAPS value */
+    value = cap_prctl(PR_GET_KEEPCAPS, 0, 0, 0, 0, 0);
+    if (value == -1) {
+        perror("worker: failed to get KEEPCAPS");
+        exit(1);
     }
-    if (pid == 0) {
-	if (cap_prctlw(PR_SET_KEEPCAPS, !start, 0, 0, 0, 0) != 0) {
-	    perror("failed to set proc");
-	    exit(1);
-	}
-	if (cap_prctlw(PR_GET_KEEPCAPS, 0, 0, 0, 0, 0) == start) {
-	    perror("failed to have set forked proc");
-	    exit(1);
-	}
-	exit(0);
-    }
-    int res;
-    if (waitpid(pid, &res, 0) != pid || res != 0) {
-	printf("FAILED: pid=%d wait returned %d and/or error: %d\n",
-	       pid, res, errno);
-	exit(1);
-    }
+
+    keepcaps_values[thread_id] = value;
+
     return NULL;
 }
 
 int main(int argc, char **argv) {
+    pthread_t threads[NUM_THREADS];
+    int thread_ids[NUM_THREADS];
+    long int initial_keepcaps, set_value, verify_value;
     int i;
-    printf("hello libcap and libpsx ");
+    int all_synchronized;
+
+#ifdef EXPECT_PSX_SYNC
+    printf("Testing libcap WITH libpsx (expecting thread synchronization)\n");
+#else
+    printf("Testing libcap WITHOUT libpsx (expecting NO thread synchronization)\n");
+#endif
     fflush(stdout);
-    long int start = cap_prctl(PR_GET_KEEPCAPS, 0, 0, 0, 0, 0);
-    if (start == -1) {
-	perror("FAILED: to actually start");
-	exit(1);
+
+    /* Initialize barrier for thread coordination */
+    pthread_barrier_init(&barrier, NULL, NUM_THREADS + 1);
+
+    /* Get initial KEEPCAPS value */
+    initial_keepcaps = cap_prctl(PR_GET_KEEPCAPS, 0, 0, 0, 0, 0);
+    if (initial_keepcaps == -1) {
+        perror("FAILED: unable to get initial KEEPCAPS");
+        exit(1);
     }
-    pthread_t ignored[10];
-    for (i = 0; i < 10; i++) {
-	pthread_create(&ignored[i], NULL, thread_fork_exit, NULL);
-	printf(".");     /* because of fork, this may print double */
-	fflush(stdout);  /* try to limit the above effect */
-	if (cap_prctlw(PR_SET_KEEPCAPS, i & 1, 0, 0, 0, 0)) {
-	    perror("failed to set proc");
-	    exit(1);
-	}
-	/*
-	 * This should validate all threads think the same thing,
-	 * and none of the fork() calls mess anything up.
-	 */
-	if (cap_prctlw(PR_GET_KEEPCAPS, 0, 0, 0, 0, 0) != (i & 1)) {
-	    perror("failed to have set proc");
-	    exit(1);
-	}
-	usleep(1000);
+
+    /*
+     * Set KEEPCAPS to a known value before creating threads.
+     * This ensures all threads start with the same state.
+     */
+    set_value = 0;
+    if (cap_prctlw(PR_SET_KEEPCAPS, set_value, 0, 0, 0, 0) != 0) {
+        perror("FAILED: unable to set initial KEEPCAPS");
+        exit(1);
     }
-    printf(" PASSED\n");
-    exit(0);
+
+    /* Create worker threads - they will inherit current KEEPCAPS value */
+    for (i = 0; i < NUM_THREADS; i++) {
+        thread_ids[i] = i;
+        if (pthread_create(&threads[i], NULL, worker_thread, &thread_ids[i]) != 0) {
+            perror("FAILED: pthread_create");
+            exit(1);
+        }
+    }
+
+    /* Wait for all threads to start */
+    pthread_barrier_wait(&barrier);
+
+    /* Wait for all threads to be ready */
+    while (__sync_fetch_and_add(&thread_ready, 0) < NUM_THREADS) {
+        usleep(1000);
+    }
+
+    /*
+     * Now change KEEPCAPS using cap_prctlw().
+     * With libpsx: this will synchronize across ALL threads via psx_syscall().
+     * Without libpsx: this affects only the calling thread via regular prctl().
+     */
+    set_value = 1;
+    if (cap_prctlw(PR_SET_KEEPCAPS, set_value, 0, 0, 0, 0) != 0) {
+        perror("FAILED: unable to set KEEPCAPS");
+        exit(1);
+    }
+
+    /* Verify main thread sees the new value */
+    verify_value = cap_prctl(PR_GET_KEEPCAPS, 0, 0, 0, 0, 0);
+    if (verify_value != set_value) {
+        printf("FAILED: main thread KEEPCAPS mismatch: expected %ld, got %ld\n",
+               set_value, verify_value);
+        exit(1);
+    }
+
+    /* Release worker threads to read their KEEPCAPS values */
+    pthread_barrier_wait(&barrier);
+
+    /* Wait for all threads to complete */
+    for (i = 0; i < NUM_THREADS; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    /* Check if all worker threads saw the synchronized value */
+    all_synchronized = 1;
+    for (i = 0; i < NUM_THREADS; i++) {
+        if (keepcaps_values[i] != set_value) {
+            all_synchronized = 0;
+        }
+    }
+
+    pthread_barrier_destroy(&barrier);
+
+    /* Verify behavior matches expectations based on linking */
+#ifdef EXPECT_PSX_SYNC
+    if (all_synchronized) {
+        printf("PASSED: All %d worker threads synchronized to KEEPCAPS=%ld\n",
+               NUM_THREADS, set_value);
+        printf("        (libpsx correctly synchronized across all threads)\n");
+        exit(0);
+    } else {
+        printf("FAILED: libpsx linked but threads not synchronized:\n");
+        printf("  Main thread KEEPCAPS: %ld\n", set_value);
+        for (i = 0; i < NUM_THREADS; i++) {
+            printf("  Worker thread %d: %d\n", i, keepcaps_values[i]);
+        }
+        exit(1);
+    }
+#else
+    if (!all_synchronized) {
+        printf("PASSED: Worker threads NOT synchronized (expected without libpsx)\n");
+        printf("  Main thread KEEPCAPS: %ld\n", set_value);
+        printf("  Worker threads KEEPCAPS: 0 (retained original value)\n");
+        exit(0);
+    } else {
+        printf("FAILED: threads synchronized but libpsx NOT linked:\n");
+        printf("  Main thread KEEPCAPS: %ld\n", set_value);
+        for (i = 0; i < NUM_THREADS; i++) {
+            printf("  Worker thread %d: %d (unexpected!)\n", i, keepcaps_values[i]);
+        }
+        printf("This suggests libpsx may be incorrectly linked\n");
+        exit(1);
+    }
+#endif
 }


### PR DESCRIPTION
The previous test would pass regardless of whether libpsx was linked because it tested prctl() calls within forked child processes rather than across threads in the same process.

The rewritten test creates worker threads and verifies that cap_prctlw() synchronizes KEEPCAPS state across all threads when linked with libpsx, but only affects the calling thread when libpsx is not linked.

The Makefile now builds two binaries from the same source:
- libcap_test: linked without -lpsx, expects no synchronization
- libcap_psx_test: linked with -lpsx, expects full synchronization

Each binary validates it observes the behavior matching its link configuration, properly testing the POSIX semantics provided by libpsx.